### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/code-of-conduct.
-
-<!-- Copyright (c) 2014 - 2024 Apple Inc. and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
swiftlang has an org wide policy in place at the .github folder and this file would override that. removing this one.